### PR TITLE
Add description of the schema language version used

### DIFF
--- a/source/description.rst
+++ b/source/description.rst
@@ -96,6 +96,7 @@ The specification of a namespace looks as follows:
 
 .. code-block:: python
 
+    # hdmf-schema-language 2.2.0
     namespaces:
     - doc: NWB namespace
       name: NWB
@@ -126,6 +127,10 @@ The specification of a namespace looks as follows:
 The top-level key must be ``namespaces``. The value of ``namespaces``
 is a list with the specification of one (or more) namespaces.
 
+The beginning of the file must begin with a comment that starts with 'hdmf-schema-language' followed by a space
+and the version string of the specification language used by this namespace, e.g.,
+``hdmf-schema-language 2.2.0``. Files without this comment are assumed to be defined
+using hdmf-schema-language 2.1.0.
 
 Namespace declaration keys
 --------------------------
@@ -208,6 +213,11 @@ consist of a list of Group specifications.
 Schemas may be distributed across multiple YAML files to improve
 readability and to support logical organization of types.
 This is the main part of the format specification. It is described in the following sections.
+
+As with files defining namespaces, the beginning of each file defining schema must begin with a comment that starts
+with 'hdmf-schema-language' followed by a space and the version string of the specification language
+used by this namespace, e.g., ``hdmf-schema-language 2.2.0``. Files without this comment are assumed to be defined
+using hdmf-schema-language 2.1.0.
 
 .. code-block:: yaml
 

--- a/source/description.rst
+++ b/source/description.rst
@@ -96,7 +96,7 @@ The specification of a namespace looks as follows:
 
 .. code-block:: python
 
-    # hdmf-schema-language 2.2.0
+    # {{ schema-language }} 2.2.0
     namespaces:
     - doc: NWB namespace
       name: NWB
@@ -127,10 +127,10 @@ The specification of a namespace looks as follows:
 The top-level key must be ``namespaces``. The value of ``namespaces``
 is a list with the specification of one (or more) namespaces.
 
-The beginning of the file must begin with a comment that starts with 'hdmf-schema-language' followed by a space
+The beginning of the file must begin with a comment that starts with '{{ schema-language }}' followed by a space
 and the version string of the specification language used by this namespace, e.g.,
-``hdmf-schema-language 2.2.0``. Files without this comment are assumed to be defined
-using hdmf-schema-language 2.1.0.
+``{{ schema-language }} 2.2.0``. Files without this comment are assumed to be defined
+using {{ schema-language }} 2.1.0.
 
 Namespace declaration keys
 --------------------------
@@ -215,9 +215,9 @@ readability and to support logical organization of types.
 This is the main part of the format specification. It is described in the following sections.
 
 As with files defining namespaces, the beginning of each file defining schema must begin with a comment that starts
-with 'hdmf-schema-language' followed by a space and the version string of the specification language
-used by this namespace, e.g., ``hdmf-schema-language 2.2.0``. Files without this comment are assumed to be defined
-using hdmf-schema-language 2.1.0.
+with '{{ schema-language }}' followed by a space and the version string of the specification language
+used by this namespace, e.g., ``{{ schema-language }} 2.2.0``. Files without this comment are assumed to be defined
+using {{ schema-language }} 2.1.0.
 
 .. code-block:: yaml
 

--- a/source/description.rst
+++ b/source/description.rst
@@ -179,6 +179,7 @@ List of the schema to be included in this namespace. The specification looks as 
 
 .. code-block:: yaml
 
+     # {{ schema_language }} 2.2.0
      - source: nwb.base.yaml
      - source: nwb.ephys.yaml
        doc: Types related to EPhys
@@ -188,6 +189,11 @@ List of the schema to be included in this namespace. The specification looks as 
      - namespace: core
        {{ data_types }}:
        - Interface
+       
+The beginning of all schema files must begin with a comment that starts with '{{ schema_language }}' followed by a space
+and the version string of the specification language used by this namespace, e.g.,
+``{{ schema_language }} 2.2.0``. Files without this comment are assumed to be defined
+using {{ schema_language }} 2.1.0.
 
 * ``source`` describes the name of the YAML (or JSON) file with the schema specification. The schema files should be
   located in the same folder as the namespace file.

--- a/source/description.rst
+++ b/source/description.rst
@@ -96,7 +96,7 @@ The specification of a namespace looks as follows:
 
 .. code-block:: python
 
-    # {{ schema-language }} 2.2.0
+    # {{ schema_language }} 2.2.0
     namespaces:
     - doc: NWB namespace
       name: NWB
@@ -127,10 +127,10 @@ The specification of a namespace looks as follows:
 The top-level key must be ``namespaces``. The value of ``namespaces``
 is a list with the specification of one (or more) namespaces.
 
-The beginning of the file must begin with a comment that starts with '{{ schema-language }}' followed by a space
+The beginning of the file must begin with a comment that starts with '{{ schema_language }}' followed by a space
 and the version string of the specification language used by this namespace, e.g.,
-``{{ schema-language }} 2.2.0``. Files without this comment are assumed to be defined
-using {{ schema-language }} 2.1.0.
+``{{ schema_language }} 2.2.0``. Files without this comment are assumed to be defined
+using {{ schema_language }} 2.1.0.
 
 Namespace declaration keys
 --------------------------
@@ -215,9 +215,9 @@ readability and to support logical organization of types.
 This is the main part of the format specification. It is described in the following sections.
 
 As with files defining namespaces, the beginning of each file defining schema must begin with a comment that starts
-with '{{ schema-language }}' followed by a space and the version string of the specification language
-used by this namespace, e.g., ``{{ schema-language }} 2.2.0``. Files without this comment are assumed to be defined
-using {{ schema-language }} 2.1.0.
+with '{{ schema_language }}' followed by a space and the version string of the specification language
+used by this namespace, e.g., ``{{ schema_language }} 2.2.0``. Files without this comment are assumed to be defined
+using {{ schema_language }} 2.1.0.
 
 .. code-block:: yaml
 

--- a/source/description.rst
+++ b/source/description.rst
@@ -179,7 +179,6 @@ List of the schema to be included in this namespace. The specification looks as 
 
 .. code-block:: yaml
 
-     # {{ schema_language }} 2.2.0
      - source: nwb.base.yaml
      - source: nwb.ephys.yaml
        doc: Types related to EPhys
@@ -189,11 +188,6 @@ List of the schema to be included in this namespace. The specification looks as 
      - namespace: core
        {{ data_types }}:
        - Interface
-       
-The beginning of all schema files must begin with a comment that starts with '{{ schema_language }}' followed by a space
-and the version string of the specification language used by this namespace, e.g.,
-``{{ schema_language }} 2.2.0``. Files without this comment are assumed to be defined
-using {{ schema_language }} 2.1.0.
 
 * ``source`` describes the name of the YAML (or JSON) file with the schema specification. The schema files should be
   located in the same folder as the namespace file.
@@ -227,6 +221,14 @@ The schema specification defines the groups, datasets and
 relationship that make up the format.
 Schemas may be distributed across multiple YAML files to improve
 readability and to support logical organization of types.
+Schema files should have the ``groups`` key and/or the ``datasets`` key at the top level.
+
+The beginning of all schema files must begin with a comment that starts with '{{ schema_language }}' followed by a space
+and the version string of the specification language used by this namespace, e.g.,
+``{{ schema_language }} 2.2.0``. Files without this comment are assumed to be defined
+using {{ schema_language }} 2.1.0. The comment at the beginning of schema files must be the 
+same as the comment at the start of the namespace file that includes the schema files. 
+
 This is the main part of the format specification. It is described in the following sections.
 
 .. note::

--- a/source/namespace_map.yml
+++ b/source/namespace_map.yml
@@ -2,5 +2,6 @@ spec_format: HDMF
 data_type_inc: data_type_inc
 data_type_def: data_type_def
 data_types: data_types
+schema-language: hdmf-schema-language
 api: hdmf
 version: '2.1.0-beta'

--- a/source/namespace_map.yml
+++ b/source/namespace_map.yml
@@ -2,6 +2,6 @@ spec_format: HDMF
 data_type_inc: data_type_inc
 data_type_def: data_type_def
 data_types: data_types
-schema-language: hdmf-schema-language
+schema_language: hdmf-schema-language
 api: hdmf
 version: '2.1.0-beta'

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -5,6 +5,8 @@ Release Notes
 Version 2.1.0 (Upcoming)
 ---------------------------------
 * First release as hdmf-schema-language.
+* Remove legacy description of the `specs` or `spec` key.
+* Add specification for the specification language used by each file.
 
 Version 2.0.2 (March, 2020)
 ---------------------------------


### PR DESCRIPTION
This PR adds a way to specify the version of the specification language used by each file (both namespace and schema files). If not specified, the default is hdmf-schema-language version 2.1.0 (the next version to be released).