### PR TITLE
Deprecate ``default_value`` and ``value`` keys for datasets

### DIFF
--- a/source/description.rst
+++ b/source/description.rst
@@ -875,8 +875,6 @@ The specification of a datasets is described in YAML as follows:
         dtype: Optional string describing the data type of the dataset
         dims: Optional list describing the names of the dimensions of the dataset
         shape: Optional list describing the shape (or possible shapes) of the dataset
-        value: Optional to fix value of dataset
-        default_value: Optional to set a default value for the dataset
         doc: Required description of the dataset
         quantity: Optional quantity identifier for the group (default=1).
         linkable: Boolean indicating whether the group is linkable (default=True)
@@ -890,6 +888,11 @@ typically manage larger data than attributes).
 The key/value pairs that make up a dataset specification are described in more detail next in Section
 :numref:`sec-dataset-spec-keys`. The keys should be ordered as specified above for readability and consistency with the
 rest of the schema.
+
+.. note::
+
+    In version 3.0, the ``value`` and ``default_value`` keys were removed for datasets. The
+    ``value`` and ``default_value`` keys were only used for attributes and are not applicable to datasets.
 
 
 .. _sec-dataset-spec-keys:
@@ -938,10 +941,6 @@ List describing the shape of the dataset. Same as for attributes. See :numref:`s
 ^^^^^^^^
 
 List describing the names of the dimensions of the dataset. Same as for attributes. See :numref:`sec-dims` for details.
-
-``value`` and ``default_value``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Same as for attributes. See :numref:`sec-value` and :numref:`sec-default_value` for details.
 
 ``doc``
 ^^^^^^^

--- a/source/hdmf.schema.json
+++ b/source/hdmf.schema.json
@@ -270,8 +270,6 @@
           "quantity": {"$ref":  "#/definitions/quantity"},
           "linkable": {"type": "boolean"},
           "attributes": {"$ref": "#/definitions/attributes"},
-          "value": {"description": "Optional constant, fixed value for the attribute."},
-          "default_value": {"description": "Optional default value for variable-valued attributes."}
         }
       }
     }

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -2,8 +2,9 @@
 Release Notes
 =============
 
-Version 2.1.0 (Upcoming)
+Version 3.0.0 (Upcoming)
 ---------------------------------
+* Deprecated the ``default_value`` and ``value`` keys for datasets.
 * First release as hdmf-schema-language.
 * Remove legacy description of the `specs` or `spec` key.
 * Add specification for the specification language used by each file.

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 
 Version 3.0.0 (Upcoming)
 ---------------------------------
-* Deprecated the ``default_value`` and ``value`` keys for datasets.
+* Deprecated the ``default_value`` and ``value`` keys for datasets. These keys are still supported for attributes.
 * Deprecated ``linkable`` key for groups and datasets.
 * First release as hdmf-schema-language.
 * Remove legacy description of the `specs` or `spec` key.


### PR DESCRIPTION
Fix #22