### PR TITLE
Restrict symbols in names

### DIFF
--- a/source/description.rst
+++ b/source/description.rst
@@ -160,8 +160,8 @@ Optional string with extended full name for the namespace.
 ``version``
 ^^^^^^^^^^^
 
-Version string for the namespace. The version string must follow the NWB versioning guidelines:
-https://www.nwb.org/versioning-guidelines/
+Version string for the namespace. The version string must not contain ":" or "/". It should follow 
+the NWB versioning guidelines: https://www.nwb.org/versioning-guidelines/
 
 ``date``
 ^^^^^^^^

--- a/source/description.rst
+++ b/source/description.rst
@@ -908,7 +908,8 @@ The key/value pairs that make up a dataset specification are described in more d
 :numref:`sec-dataset-spec-keys`. The keys should be ordered as specified above for readability and consistency with the
 rest of the schema.
 
-The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must not contain ":" or "/".
+The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must follow the 
+regular expression pattern: ``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
 
 .. note::
 

--- a/source/description.rst
+++ b/source/description.rst
@@ -854,7 +854,8 @@ Link specification keys
 ``name``
 ^^^^^^^^
 
-Optional key specifying the ``name`` of the link.
+Optional key specifying the ``name`` of the link. The name must follow the 
+regular expression pattern: ``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
 
 ``target_type``
 ^^^^^^^^^^^^^^^

--- a/source/description.rst
+++ b/source/description.rst
@@ -271,7 +271,8 @@ Groups are specified as part of the top-level list or via lists stored in the ke
 The key/value pairs that make up a group specification are described in more detail next in Section :numref:`sec-group-spec-keys`.
 The keys should be ordered as specified above for readability and consistency with the rest of the schema.
 
-The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must not contain ":" or "/".
+The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must follow the regular
+expression pattern: ``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
 
 .. note::
 

--- a/source/description.rst
+++ b/source/description.rst
@@ -150,7 +150,7 @@ Text description of the namespace.
 ``name``
 ^^^^^^^^
 
-Unique name used to refer to the namespace.
+Unique name used to refer to the namespace. The name must not contain ":", "/", or whitespace.
 
 ``full_name``
 ^^^^^^^^^^^^^
@@ -160,7 +160,8 @@ Optional string with extended full name for the namespace.
 ``version``
 ^^^^^^^^^^^
 
-Version string for the namespace
+Version string for the namespace. The version string must follow the NWB versioning guidelines:
+https://www.nwb.org/versioning-guidelines/
 
 ``date``
 ^^^^^^^^
@@ -269,6 +270,8 @@ Groups are specified as part of the top-level list or via lists stored in the ke
 
 The key/value pairs that make up a group specification are described in more detail next in Section :numref:`sec-group-spec-keys`.
 The keys should be ordered as specified above for readability and consistency with the rest of the schema.
+
+The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must not contain ":" or "/".
 
 .. note::
 
@@ -539,7 +542,8 @@ Attribute specification keys
 ^^^^^^^^
 
 String with the name for the attribute. The ``name`` key is required and must
-specify a unique attribute on the current parent object (e.g., group or dataset)
+specify a unique attribute on the current parent object (e.g., group or dataset).
+The name must not contain whitespace.
 
 .. _sec-dtype:
 
@@ -901,6 +905,8 @@ typically manage larger data than attributes).
 The key/value pairs that make up a dataset specification are described in more detail next in Section
 :numref:`sec-dataset-spec-keys`. The keys should be ordered as specified above for readability and consistency with the
 rest of the schema.
+
+The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must not contain ":" or "/".
 
 .. note::
 

--- a/source/description.rst
+++ b/source/description.rst
@@ -271,8 +271,8 @@ Groups are specified as part of the top-level list or via lists stored in the ke
 The key/value pairs that make up a group specification are described in more detail next in Section :numref:`sec-group-spec-keys`.
 The keys should be ordered as specified above for readability and consistency with the rest of the schema.
 
-The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must follow the regular
-expression pattern: ``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
+The ``name``, ``default_name``, ``{{ data_type_def }}``, and ``{{ data_type_inc }}``  must follow the 
+regular expression pattern: ``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
 
 .. note::
 

--- a/source/description.rst
+++ b/source/description.rst
@@ -544,7 +544,8 @@ Attribute specification keys
 
 String with the name for the attribute. The ``name`` key is required and must
 specify a unique attribute on the current parent object (e.g., group or dataset).
-The name must not contain whitespace.
+The name must follow the regular expression pattern: 
+``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
 
 .. _sec-dtype:
 


### PR DESCRIPTION
## Namespace name
When HDMF caches schema, groups are created based on the namespace name. Therefore the namespace name must not contain `"/"` for both HDF5 and Zarr backends. They should also not contain `":"` for Zarr backends on Windows because `":"` is not allowed in a file name. (There are actually many characters that are not allowed in filenames on Windows, but `":"` is probably the most likely to be used.) We should consider restricting the other ones. Ref: https://github.com/hdmf-dev/hdmf-zarr/issues/219

The schema already states that namespace names cannot contain whitespace (I don't know why).

**Proposal: Additionally disallow "/" and ":" (in addition to whitespace) from namespace names**

## Version string
Groups are also created based on the version string. The version string should follow the NWB versioning guidelines: https://www.nwb.org/versioning-guidelines/
I do not think we need to be strict about this, but at least, the version string must not contain `"/"` and should not contain `":"`.

**Proposal: Disallow "/" and ":" whitespace from version strings**

## Fixed group, dataset, attribute, and link names
For the same reason as above, names of groups and datasets, which may be set in schema or defined by users, must not contain `"/"` and should not contain `":"`. This restriction is already set in HDMF. https://github.com/hdmf-dev/hdmf/pull/1202

Fixed names of groups, datasets, attributes, and links (things that could be properties of a class) and default names of groups and datasets set in a schema must follow the pattern `"^[A-Za-z_][A-Za-z0-9_]*$"` for compatibility with the MatNWB and PyNWB APIs: https://github.com/NeurodataWithoutBorders/matnwb/issues/35

The above link only discusses whitespace for Matlab, but Matlab allows only the above pattern for field names, property names, and variable names. https://www.mathworks.com/help/matlab/ref/struct.html

Python attribute names have the same restriction. (Matlab additionally says the maximum length of a name = 63 characters currently.)

In HDMF, we have already blocked creating fixed names of groups and datasets with `"/"`: https://github.com/hdmf-dev/hdmf/pull/1219

**Proposal: Require fixed names for groups, datasets, attributes, and links set in schema to follow the pattern `"^[A-Za-z_][A-Za-z0-9_]*$"`**

## Data type names
When generating classes, PyNWB and MatNWB use `data_type_def` as the class name. 
Python class names must follow the pattern `"^[A-Za-z_][A-Za-z0-9_]*$"` (plus some allowance of non-ASCII characters): https://docs.python.org/3/reference/lexical_analysis.html#identifiers . 
Matlab class names follow the same rules: https://www.mathworks.com/help/matlab/ref/classdef.html

Therefore,`data_type_def` values should follow the same pattern `"^[A-Za-z_][A-Za-z0-9_]*$"`.

**Proposal: Require data type names to follow the pattern `"^[A-Za-z_][A-Za-z0-9_]*$"`**

The last two proposals were previously proposed in https://github.com/NeurodataWithoutBorders/nwb-schema-language/issues/1 . I am just reviving that issue here and adding to it.