### PR TITLE
Clarify that unspecified dtype allows any dtype

### DIFF
--- a/source/description.rst
+++ b/source/description.rst
@@ -614,6 +614,11 @@ String specifying the data type of the attribute. Allowable values are:
 
     Prior to version 3.0, ``int`` was synonymous with ``int32``, and ``uint`` was not listed.
 
+.. note::
+
+    If ``dtype`` is not specified, then any ``dtype`` is allowed, including any of the basic
+    ``dtype`` spec values listed above, any reference ``dtype``, or any compound ``dtype``.
+
 Reference ``dtype``
 """""""""""""""""""
 

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -27,6 +27,8 @@ Version 3.0.0 (Upcoming)
   expression ``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
 * Specified that data_type_def (and therefore also data_type_inc) must follow the regular
   expression ``^[A-Za-z_][A-Za-z0-9_]*$`` to ensure compatibility across APIs.
+* Clarified that if ``dtype`` is not specified, then any ``dtype`` is allowed, including any basic
+  ``dtype`` spec value, any reference ``dtype``, or any compound ``dtype``.
 
 Version 2.0.2 (March, 2020)
 ---------------------------------


### PR DESCRIPTION
## Summary
- Clarified in the ``dtype`` documentation that if ``dtype`` is not specified, any basic, reference, or compound ``dtype`` is allowed.
- Added a corresponding entry to the 3.0.0 release notes.

Fixes #48

## Test plan
- [x] Verify rendered docs show the new note under the ``dtype`` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)